### PR TITLE
CI 멀티 OS 설정 제거

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -4,11 +4,10 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-18.04]
         node-version: [14.x]
 
     steps:
@@ -18,5 +17,5 @@ jobs:
         run: rm -rf node_modules && yarn install --frozen-lockfile
       - name: Run lint
         run: yarn lint
-      - name: Run unit test
+      - name: Run test
         run: yarn test


### PR DESCRIPTION
멀티 OS 설정 작동 결과가 궁금해서 설정해봤지만, OS별로 필요한 명령어가 달라 빌드 실패로 이어졌다.
지금 프로젝트에서는 필요없는 설정이라 다시 우분투로 설정을 복구했다.