### PR TITLE
운동페이지 준비 운동 부분 구현

### DIFF
--- a/cypress/integration/setting-page.spec.js
+++ b/cypress/integration/setting-page.spec.js
@@ -5,7 +5,7 @@ describe('SettingPage', () => {
 
   it('contains setting page outline', () => {
     cy.get('h1')
-      .should('have.text', '운동 설정하기')
+      .should('have.text', 'Setting')
       .get('#setting-warmup')
       .contains('h2', '준비운동')
       .get('#setting-strengthwork')

--- a/cypress/integration/workout-page.spec.js
+++ b/cypress/integration/workout-page.spec.js
@@ -1,0 +1,45 @@
+describe('WorkoutPage', () => {
+  beforeEach(() => {
+    cy.visit('/workout');
+  });
+
+  it('shows workout page outline', () => {
+    cy.get('#heading-warmup')
+      .should('have.text', '준비운동')
+      .get('#heading-strengthwork')
+      .should('have.text', '근력운동');
+  });
+
+  describe('warmup', () => {
+    it('can input exercise reps', () => {
+      cy.get('input[type="number"]')
+        .each((element) => {
+          cy.wrap(element).type('10');
+        });
+    });
+
+    it('activates or deactivates input field by clicking done button', () => {
+      cy.get('button[id^=toggle-]')
+        .each((element) => {
+          cy.wrap(element)
+            .click();
+        })
+        .get('input[type="number"]')
+        .each((element) => {
+          cy.wrap(element)
+            .should('be.disabled');
+        });
+
+      cy.get('button[id^=toggle-]')
+        .each((element) => {
+          cy.wrap(element)
+            .click();
+        })
+        .get('input[type="number"]')
+        .each((element) => {
+          cy.wrap(element)
+            .should('not.be.disabled');
+        });
+    });
+  });
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,12 +7,14 @@ import {
 
 import HomePage from './pages/Home';
 import SettingPage from './pages/Setting';
+import WorkoutPage from './pages/Workout';
 
 export default function App() {
   return (
     <Switch>
       <Route exact path="/" component={HomePage} />
       <Route path="/setting" component={SettingPage} />
+      <Route path="/workout" component={WorkoutPage} />
     </Switch>
   );
 }

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -23,7 +23,7 @@ describe('App', () => {
     useSelector.mockImplementation((selector) => selector({
       setting: {
         warmup: {
-          yuri: false,
+          yuri: true,
           squatSkyReach: false,
           gmbWristPrep: false,
           deadbug: false,
@@ -44,7 +44,12 @@ describe('App', () => {
           extension: '',
         },
       },
-      warmups: [],
+      warmups: [
+        {
+          name: 'yuri',
+          label: '',
+        },
+      ],
       progressions: {
         pullup: [],
         squat: [],
@@ -55,6 +60,9 @@ describe('App', () => {
         antiExtension: [],
         antiRotation: [],
         extension: [],
+      },
+      record: {
+        warmup: {},
       },
     }));
   });
@@ -73,6 +81,17 @@ describe('App', () => {
     it('renders SettingPage', () => {
       const { container } = renderApp({ path: '/setting' });
 
+      expect(container).toHaveTextContent(/Setting/);
+      expect(container).toHaveTextContent(/준비운동/);
+      expect(container).toHaveTextContent(/근력운동/);
+    });
+  });
+
+  context('with path /workout', () => {
+    it('renders WorkoutPage', () => {
+      const { container } = renderApp({ path: '/workout' });
+
+      expect(container).toHaveTextContent(/Workout/);
       expect(container).toHaveTextContent(/준비운동/);
       expect(container).toHaveTextContent(/근력운동/);
     });

--- a/src/components/WarmupInput.jsx
+++ b/src/components/WarmupInput.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+export default function WarmupInput({ exercise, onChange, onClick }) {
+  const {
+    name, label, range, reps,
+  } = exercise;
+  return (
+    <label
+      key={name}
+      htmlFor={name}
+    >
+      {label}
+      <span>{range}</span>
+      <input
+        type="number"
+        id={name}
+        name={name}
+        value={reps}
+        onChange={onChange}
+      />
+      <button
+        type="button"
+        id={`toggle-${name}`}
+        onClick={() => onClick({ id: name })}
+      >
+        완료
+      </button>
+    </label>
+  );
+}

--- a/src/components/WarmupInput.test.jsx
+++ b/src/components/WarmupInput.test.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+import { render, fireEvent } from '@testing-library/react';
+
+import WarmupInput from './WarmupInput';
+
+import {
+  deadbug,
+  easierSquat,
+  easierHinge,
+} from '../data/warmups';
+
+describe('WarmupInput', () => {
+  function renderWarmupInput({ exercise }) {
+    return render(
+      <WarmupInput
+        exercise={exercise}
+      />,
+    );
+  }
+
+  function checkInput(input) {
+    fireEvent.change(input, { target: { value: 99 } });
+    expect(input.valueAsNumber).toBe(99);
+  }
+
+  it('provides input of the warmup reps', () => {
+    const { container } = renderWarmupInput({ exercise: deadbug });
+
+    expect(container).toHaveTextContent('Deadbug');
+    expect(container).toHaveTextContent('30s');
+
+    const input = container.querySelector('#deadbug');
+    checkInput(input);
+  });
+
+  context('with easier squat', () => {
+    it('renders easier squat input', () => {
+      const { container } = renderWarmupInput({ exercise: easierSquat });
+
+      const input = container.querySelector('#easierSquat');
+
+      checkInput(input);
+    });
+  });
+
+  context('with easier hinge', () => {
+    it('renders easier hinge input', () => {
+      const { container } = renderWarmupInput({ exercise: easierHinge });
+
+      const input = container.querySelector('#easierHinge');
+
+      checkInput(input);
+    });
+  });
+});

--- a/src/components/WarmupInputGroup.jsx
+++ b/src/components/WarmupInputGroup.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import WarmupInput from './WarmupInput';
+
+export default function WarmupInputGroup({ workout, onChange, onClick }) {
+  return (
+    <fieldset id="fieldset-warmup">
+      <legend>
+        <h2 id="heading-warmup">준비운동</h2>
+      </legend>
+      <div id="header-input-warmup">
+        <span>범위</span>
+        <span>횟수</span>
+      </div>
+      <div id="group-input-warmup">
+        {workout.map((exercise) => (
+          <WarmupInput
+            key={exercise.name}
+            exercise={exercise}
+            onChange={onChange}
+            onClick={onClick}
+          />
+        ))}
+      </div>
+    </fieldset>
+  );
+}

--- a/src/components/WarmupInputGroup.test.jsx
+++ b/src/components/WarmupInputGroup.test.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import WarmupInputGroup from './WarmupInputGroup';
+
+describe('WarmupInputGroup', () => {
+  const workout = [
+    {
+      level: 0,
+      name: 'foo',
+      label: 'Foo',
+    },
+  ];
+
+  it('renders warmup header', () => {
+    const { container } = render(
+      <WarmupInputGroup
+        workout={workout}
+      />,
+    );
+
+    expect(container).toHaveTextContent('준비운동');
+    expect(container).toHaveTextContent('범위');
+    expect(container).toHaveTextContent('횟수');
+  });
+});

--- a/src/components/WarmupInputGroupContainer.jsx
+++ b/src/components/WarmupInputGroupContainer.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+
+import { useDispatch, useSelector } from 'react-redux';
+
+import { setWarmupRecord } from '../slice';
+
+import WarmupInputGroup from './WarmupInputGroup';
+
+export default function WarmupInputGroupContainer() {
+  const dispatch = useDispatch();
+
+  function handleChange(event) {
+    const { id, valueAsNumber } = event.target;
+
+    dispatch(setWarmupRecord({
+      exercise: id,
+      reps: valueAsNumber,
+    }));
+  }
+
+  function toggleInputActivation({ id }) {
+    document.querySelector(`#${id}`).disabled = !document.querySelector(`#${id}`).disabled;
+  }
+
+  const setting = useSelector((state) => state.setting.warmup);
+  const warmups = useSelector((state) => state.warmups);
+  const squat = useSelector((state) => state.setting.strengthwork.squat);
+  const hinge = useSelector((state) => state.setting.strengthwork.hinge);
+  const record = useSelector((state) => state.record.warmup);
+
+  const checkedList = Object
+    .entries(setting)
+    .filter(([name, isChecked]) => name && isChecked)
+    .map((exercise) => exercise[0]);
+
+  const workout = checkedList.map((name) => {
+    const isEasierSquat = name === 'easierSquat';
+    const isEasierHinge = name === 'easierHinge';
+
+    if (isEasierSquat) {
+      const easierSquat = warmups
+        .find((target) => target.name === name)
+        .getEasierSquat(squat);
+
+      return {
+        ...easierSquat,
+        name: 'easierSquat',
+        reps: record[name] || '',
+      };
+    }
+
+    if (isEasierHinge) {
+      const easierHinge = warmups
+        .find((target) => target.name === name)
+        .getEasierHinge(hinge);
+
+      return {
+        ...easierHinge,
+        name: 'easierHinge',
+        reps: record[name] || '',
+      };
+    }
+
+    const exercise = warmups.find((target) => target.name === name);
+
+    return {
+      ...exercise,
+      reps: record[name] || '',
+    };
+  });
+
+  return (
+    <WarmupInputGroup
+      workout={workout}
+      onChange={handleChange}
+      onClick={toggleInputActivation}
+    />
+  );
+}

--- a/src/components/WarmupInputGroupContainer.test.jsx
+++ b/src/components/WarmupInputGroupContainer.test.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+
+import { useDispatch, useSelector } from 'react-redux';
+
+import WarmupInputGroupContainer from './WarmupInputGroupContainer';
+
+jest.mock('react-redux');
+
+describe('WarmupInputGroupContainer', () => {
+  const dispatch = jest.fn();
+
+  beforeEach(() => {
+    useDispatch.mockImplementation(() => dispatch);
+    useSelector.mockImplementation((selector) => selector({
+      setting: {
+        warmup: {
+          easierSquat: true,
+          easierHinge: true,
+        },
+        strengthwork: {},
+      },
+      warmups: [
+        {
+          name: 'easierSquat',
+          getEasierSquat: () => ({
+            name: 'foo',
+          }),
+        },
+        {
+          name: 'easierHinge',
+          getEasierHinge: () => ({
+            name: 'bar',
+          }),
+        },
+      ],
+      record: {
+        warmup: {},
+      },
+    }));
+  });
+
+  it('renders without crash', () => {
+    render(<WarmupInputGroupContainer />);
+  });
+
+  it('dispatches warmup workout input', () => {
+    const { container } = render(<WarmupInputGroupContainer />);
+
+    const easierSquat = container.querySelector('#easierSquat');
+
+    fireEvent.change(easierSquat, { target: { value: 99 } });
+    expect(dispatch).toBeCalledTimes(1);
+  });
+
+  it('toggles warmup workout input by button', () => {
+    const { container } = render(<WarmupInputGroupContainer />);
+
+    const button = container.querySelector('#toggle-easierSquat');
+
+    fireEvent.click(button);
+  });
+});

--- a/src/components/WorkoutForm.jsx
+++ b/src/components/WorkoutForm.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import WarmupInputGroupContainer from './WarmupInputGroupContainer';
+
+export default function WorkoutForm() {
+  return (
+    <form id="form-workout">
+      <WarmupInputGroupContainer />
+      <fieldset id="fieldset-strengthwork">
+        <legend>
+          <h2 id="heading-strengthwork">근력운동</h2>
+        </legend>
+      </fieldset>
+    </form>
+  );
+}

--- a/src/components/WorkoutForm.test.jsx
+++ b/src/components/WorkoutForm.test.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import { useSelector } from 'react-redux';
+
+import WorkoutForm from './WorkoutForm';
+
+jest.mock('react-redux');
+
+describe('WorkoutForm', () => {
+  it('renders without crash', () => {
+    useSelector.mockImplementation((selector) => selector({
+      setting: {
+        warmup: {},
+        strengthwork: {},
+      },
+      warmups: [],
+      record: {
+        warmup: {},
+      },
+    }));
+
+    render(<WorkoutForm />);
+  });
+});

--- a/src/pages/Setting.jsx
+++ b/src/pages/Setting.jsx
@@ -6,7 +6,7 @@ import StrengthworkFormContainer from '../components/StrengthworkFormContainer';
 export default function SettingPage() {
   return (
     <main>
-      <h1>운동 설정하기</h1>
+      <h1>Setting</h1>
       <WarmupFormContainer />
       <StrengthworkFormContainer />
     </main>

--- a/src/pages/Workout.jsx
+++ b/src/pages/Workout.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import WorkoutForm from '../components/WorkoutForm';
+
+export default function WorkoutPage() {
+  return (
+    <main>
+      <h1>Workout</h1>
+      <WorkoutForm />
+    </main>
+  );
+}

--- a/src/pages/Workout.test.jsx
+++ b/src/pages/Workout.test.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import { useSelector } from 'react-redux';
+
+import Workout from './Workout';
+
+jest.mock('react-redux');
+
+describe('WorkoutPage', () => {
+  it('renders without crash', () => {
+    useSelector.mockImplementation((selector) => selector({
+      setting: {
+        warmup: {},
+        strengthwork: {},
+      },
+      warmups: [],
+      record: {
+        warmup: {},
+      },
+    }));
+
+    const { container } = render(
+      <Workout />,
+    );
+
+    expect(container).toHaveTextContent('Workout');
+  });
+});

--- a/src/slice.js
+++ b/src/slice.js
@@ -29,6 +29,9 @@ const { actions, reducer } = createSlice({
         extension: 'reverseHyperextension',
       },
     },
+    record: {
+      warmup: {},
+    },
     warmups,
     progressions,
   },
@@ -57,12 +60,25 @@ const { actions, reducer } = createSlice({
         },
       };
     },
+    setWarmupRecord(state, { payload: { exercise, reps } }) {
+      return {
+        ...state,
+        record: {
+          ...state.record,
+          warmup: {
+            ...state.record.warmup,
+            [exercise]: reps,
+          },
+        },
+      };
+    },
   },
 });
 
 export const {
   setWarmup,
   setStrengthwork,
+  setWarmupRecord,
 } = actions;
 
 export default reducer;

--- a/src/slice.test.js
+++ b/src/slice.test.js
@@ -1,6 +1,7 @@
 import reducer, {
   setWarmup,
   setStrengthwork,
+  setWarmupRecord,
 } from './slice';
 
 test('setWarmup', () => {
@@ -36,4 +37,22 @@ test('setStrengthwork', () => {
 
   expect(state.setting.strengthwork.foo).toBe('some exercise');
   expect(state.setting.strengthwork.bar).toBe('bar');
+});
+
+test('setWarmupRecord', () => {
+  const initialState = {
+    record: {
+      warmup: {
+        bar: 0,
+      },
+    },
+  };
+
+  const state = reducer(initialState, setWarmupRecord({
+    exercise: 'foo',
+    reps: 99,
+  }));
+
+  expect(state.record.warmup.foo).toBe(99);
+  expect(state.record.warmup.bar).toBe(0);
 });


### PR DESCRIPTION
# PR 개요

프로젝트는 4개의 페이지(home, setting, workout, records)가 있는데, workout 페이지 내부의 준비운동 부분을 구현했습니다.

- 사용자는 각 준비운동의 수행 횟수를 입력할 수 있습니다.
  - 입력된 수행 횟수는 상태 변경을 일으킵니다.
- 사용자는 버튼을 눌러 입력 필드를 활성화, 비활성화 할 수 있습니다.